### PR TITLE
fix: Add validation for missing name attributes in platform and parti…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brandonarrindell/homebridge-envisalink",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brandonarrindell/homebridge-envisalink",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "dateformat": ">=1.0.12 <5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge EnvisaLink (Fork)",
   "name": "@brandonarrindell/homebridge-envisalink",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A homebridge plugin for the EnvisaLink alarm module - Maintained fork of homebridge-envisalink",
   "main": "dist/index.js",
   "scripts": {
@@ -53,7 +53,7 @@
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",
     "eslint": "^8.40.0",
-    "homebridge": "^1.6.0 || ^2.0.0-beta.0", 
+    "homebridge": "^1.6.0 || ^2.0.0-beta.0",
     "nodemon": "^2.0.20",
     "rimraf": "^5.0.0",
     "ts-node": "^10.9.1",

--- a/src/configTypes.ts
+++ b/src/configTypes.ts
@@ -2,7 +2,7 @@ import {PlatformConfig} from 'homebridge';
 import {ZoneType} from './types';
 
 export type PartitionConfig = {
-    name: string;
+    name?: string;
     enableChimeSwitch?: boolean;
     pin?: string;
 };
@@ -27,6 +27,7 @@ export type CustomCommandConfig = {
 export type EnvisalinkConfig = {
     host?: string;
     enableAutoDiscovery?: boolean;
+    name?: string;
     password: string;
     port: number;
     proxyPort: number;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -59,11 +59,16 @@ export class EnvisalinkHomebridgePlatform implements DynamicPlatformPlugin {
         public readonly config: PlatformConfig,
         public readonly api: HomebridgeAPI,
     ) {
-        this.log.debug('Finished initializing platform:', this.config.name);
+        this.log.debug('Finished initializing platform:', this.getConfig().name || this.config.name || 'Envisalink');
 
         const co = this.getConfig();
         this.alarm = undefined;
         this.zoneConfigs = new Map();
+
+        // Validate platform name - missing name causes warning
+        if (!co.name && !this.config.name) {
+            this.log.warn('Platform configuration is missing a name attribute. Using default name "Envisalink".');
+        }
 
         if (!co || !co.password || !co.pin) {
             this.log.warn('Platform will be skipped because config is missing password and/or pin.');
@@ -73,6 +78,15 @@ export class EnvisalinkHomebridgePlatform implements DynamicPlatformPlugin {
         if (!co.partitions || co.partitions.length === 0) {
             this.log.warn('Platform will be skipped partitions were not configured.');
             return;
+        }
+
+        // Validate partition names - missing names can cause failures
+        for (let i = 0; i < co.partitions.length; i++) {
+            const partition = co.partitions[i];
+            if (!partition.name) {
+                this.log.warn(`Partition ${i + 1} is missing a name attribute. Using default name "Partition ${i + 1}".`);
+                this.log.warn('Missing partition names can cause plugin failures. Please add name attributes to your partition configurations.');
+            }
         }
 
         if (!co.zones || co.zones.length === 0) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -55,8 +55,9 @@ export const transformPartitionStatus = (partitionConfigs: ReadonlyArray<Partiti
     const chimeEnabled: boolean | undefined = statusCode === EnvisalinkStatusCode.ChimeEnabled ? true
         : statusCode === EnvisalinkStatusCode.ChimeDisabled ? false
             : undefined;
+    const partitionName = partitionConfig.name || `Partition ${number}`;
     return {
-        name: partitionConfig.name,
+        name: partitionName,
         number: number,
         enableChimeSwitch: partitionConfig.enableChimeSwitch || false,
         chimeCommand: `071${number}*4`,


### PR DESCRIPTION
 fix: Add validation for missing name attributes in platform and partition configs
    
    - Add validation for missing platform name attribute (fixes warnings)
    - Add validation for missing partition name attributes (prevents failures)
    - Maintain backwards compatibility with fallback logic
    - Bump version to 1.3.1
    
    Fixes #45 - Missing name attribute in 2 locations causing plugin failures