### PR TITLE
Fix PLUGIN_NAME mismatch after package rename to scoped name

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,4 +6,4 @@ export const PLATFORM_NAME = 'Envisalink';
 /**
  * This must match the name of your plugin as defined the package.json
  */
-export const PLUGIN_NAME = 'homebridge-envisalink';
+export const PLUGIN_NAME = '@brandonarrindell/homebridge-envisalink';


### PR DESCRIPTION
## Summary
- `package.json` declares this plugin as `@brandonarrindell/homebridge-envisalink`, but `src/settings.ts` still hardcoded the pre-rename unscoped name (`homebridge-envisalink`) for `PLUGIN_NAME`.
- This constant is used in `registerPlatformAccessories()` / `unregisterPlatformAccessories()`, so every newly-created accessory (e.g. a new custom command) gets tagged with a plugin identity Homebridge no longer recognizes as loaded.
- Symptom seen in the Homebridge log on every restart after adding a new accessory:
  ```
  A platform configured a new accessory under the plugin name 'homebridge-envisalink'. However no loaded plugin could be found for the name!
  ```
- This leaves newly-registered accessories in a broken bookkeeping state and can make them unreliable/slow to surface correctly in HomeKit clients.

## Test plan
- [x] `npm run build` succeeds with no TypeScript errors
- [x] Verified `PLUGIN_NAME` now matches `package.json`'s `name` field exactly
- [x] Deployed to a real Homebridge 2.x instance; confirmed the "no loaded plugin could be found for the name" warning no longer appears on restart after adding a new custom command accessory