### PR TITLE
Clarify custom command format requires full TPI packet, not raw keypad code

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,18 +154,26 @@ For systems with gaps in zone numbering:
 
 ### Custom Commands
 
-Add custom panel commands:
+Add custom panel commands. Each `command` is sent to the EnvisaLink as a raw TPI command string — it is **not** just a keypad code. To simulate a keystroke sequence on a specific partition (arming variants, bypass, etc.), use TPI command `071` (Send Keystring) followed by the partition number and then the keys, e.g. `071<partition><keys>`:
 
 ```json
 {
   "customCommands": [
     {
       "name": "System Test",
-      "command": "071*600004"
+      "command": "0711*600004"
+    },
+    {
+      "name": "Instant Arm (Away)",
+      "command": "0711*9XXXX"
     }
   ]
 }
 ```
+
+`Instant Arm (Away)` above simulates pressing `*9` plus a 4-digit alarm code on partition 1 (replace `XXXX` with your code) — the DSC instant-arm sequence.
+
+A command missing the `071<partition>` prefix (e.g. just `*9XXXX`) will be rejected by the panel with a `Bad Checksum Received` error, since it is not a valid standalone TPI packet.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- The existing \`customCommands\` README example (\`071*600004\`) is itself missing the partition digit that the \`071\` (Send Keystring) TPI command requires — easy to misread as "just paste the keypad sequence you'd press on the panel."
- A command like \`*9<code>\` (DSC instant-arm) sent without the \`071<partition>\` wrapper is not a valid standalone TPI packet, and the panel rejects it with \`Bad Checksum Received\` — a fairly opaque error with no pointer back to the actual cause (missing prefix).
- Adds an explicit note on the required format, fixes the partition digit in the existing example, and adds a second worked example (instant-arm) since it's a common ask.

## Test plan
- Documentation-only change, no code affected.